### PR TITLE
[feat] 키워드를 통해 질문 조회 기능 구현

### DIFF
--- a/admin/admin-api/src/main/java/dev/donggi/core/api/web/AdminRestController.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/web/AdminRestController.java
@@ -4,11 +4,14 @@ import dev.donggi.core.api.common.response.ApiResponse;
 import dev.donggi.core.api.core.domain.AuthenticatedMember;
 import dev.donggi.core.api.core.question.application.QuestionService;
 import dev.donggi.core.api.core.question.application.dto.QuestionDto;
+import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
 import dev.donggi.core.api.web.dto.LoginMember;
+import dev.donggi.core.api.core.question.application.dto.QuestionPaginationDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +25,15 @@ public class AdminRestController {
     public ApiResponse<QuestionDto> getByQuestion(@AuthenticatedMember LoginMember loginMember,
                                                   @PathVariable("questionId") Long questionId) {
         QuestionDto question = questionService.getQuestion(questionId);
+        return ApiResponse.success(question);
+    }
+
+    @GetMapping("/question/search")
+    public ApiResponse<QuestionPaginationDto> searchQuestions(@AuthenticatedMember LoginMember loginMember,
+                                                              @RequestParam("content") String content,
+                                                              @RequestParam(required = false, defaultValue = "0") String searchAfterId,
+                                                              @RequestParam(required = false, defaultValue = "30") String size) {
+        QuestionPaginationDto question = questionService.searchByContent(content, new NoOffsetPageCommand(searchAfterId, size));
         return ApiResponse.success(question);
     }
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/QuestionFinder.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/QuestionFinder.java
@@ -1,7 +1,9 @@
 package dev.donggi.core.api.core.question.application;
 
 import dev.donggi.core.api.core.question.application.dto.QuestionDto;
+import dev.donggi.core.api.core.question.application.dto.QuestionPaginationDto;
 import dev.donggi.core.api.core.question.application.dto.RandomQuestionsDto;
+import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
 
 public interface QuestionFinder {
 
@@ -20,4 +22,12 @@ public interface QuestionFinder {
      * @return QuestionDto 조회한 Question 이 포함된 객체
      */
     QuestionDto getQuestion(Long questionId);
+
+    /**
+     * 검색을 통해 질문을 조회합니다.
+     *
+     * @param content 검색할 content
+     * @return QuestionPaginationDto 페이징 처리가 된 Question 객체
+     */
+    QuestionPaginationDto searchByContent(String content, NoOffsetPageCommand pageCommand);
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/dto/QuestionPaginationDto.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/dto/QuestionPaginationDto.java
@@ -1,0 +1,33 @@
+package dev.donggi.core.api.core.question.application.dto;
+
+import dev.donggi.core.api.core.common.PageDto;
+import dev.donggi.core.api.core.question.domain.Question;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class QuestionPaginationDto {
+
+    private String content;
+    private List<QuestionDto> questions = new ArrayList<>();
+    private PageDto page;
+
+    public static QuestionPaginationDto ofEntity(Slice<Question> sliceQuestion, String content) {
+        QuestionPaginationDto questionPaginationDto = new QuestionPaginationDto();
+        questionPaginationDto.content = content;
+
+        List<Question> questions = sliceQuestion.getContent();
+        questionPaginationDto.questions = questions.stream()
+            .map(QuestionDto::ofEntity)
+            .collect(Collectors.toList());
+
+        int postsSize = questions.size();
+        long nextId = questions.isEmpty() ? 0L : questions.get(postsSize - 1).getId();
+        questionPaginationDto.page = new PageDto(postsSize, nextId, sliceQuestion.isLast());
+
+        return questionPaginationDto;
+    }
+}

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/domain/QuestionRepository.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/domain/QuestionRepository.java
@@ -2,6 +2,8 @@ package dev.donggi.core.api.core.question.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface QuestionRepository {
 
@@ -30,4 +32,21 @@ public interface QuestionRepository {
      * @return Optional<Question> 객체
      */
     Optional<Question> findById(Long questionId);
+
+    /**
+     * 저장소에서 id의 최대값을 찾습니다.
+     *
+     * @return id 최대값
+     */
+    Optional<Long> findMaxId();
+
+    /**
+     * 저장소에서 검색 키워드를 통해 question 를 검색합니다.
+     *
+     * @param content 검색할 키워드
+     * @param searchAfterId 검색 기준 대상
+     * @param ofSize 페이지 크기
+     * @return 페이징 된 질문 객체
+     */
+    Slice<Question> findByContent(String content, Long searchAfterId, Pageable ofSize);
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/infrastructure/QuestionJpaRepository.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/infrastructure/QuestionJpaRepository.java
@@ -3,6 +3,9 @@ package dev.donggi.core.api.core.question.infrastructure;
 import dev.donggi.core.api.core.question.domain.Question;
 import dev.donggi.core.api.core.question.domain.QuestionRepository;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +14,10 @@ public interface QuestionJpaRepository extends QuestionRepository, JpaRepository
 
     @Query(value = "select q.id from Question q where q.category in :categories")
     List<Long> findAllIdsByCategories(@Param("categories") List<String> categories);
+
+    @Query(value = "select max(q.id) from Question q")
+    Optional<Long> findMaxId();
+
+    @Query(value = "select q from Question q where q.content.content like %:content% and q.id <= :searchAfterId order by q.id desc")
+    Slice<Question> findByContent(@Param("content") String content, @Param("searchAfterId") Long searchAfterId, Pageable ofSize);
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

#77 

<br>

### 📝 구현 내용

- 입력 받은 키워드를 Question 테이블의 content 컬럼에 해당하는 키워드가 존재하면 해당 Question 데이터를 반환

<br>

### 💡 결과 & 참고 자료

<img width="561" alt="image" src="https://github.com/beside-kkeuroolryo/golraba/assets/73376468/c2fd7d67-39fa-496f-859e-810e0c3fc71b">
