### PR TITLE
[refactor] Question 검색 로직 admin 모듈로 이동

### DIFF
--- a/admin/admin-api/src/main/java/dev/donggi/core/api/common/argumentresolver/AuthenticationMemberArgumentResolver.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/common/argumentresolver/AuthenticationMemberArgumentResolver.java
@@ -1,9 +1,9 @@
 package dev.donggi.core.api.common.argumentresolver;
 
-import dev.donggi.core.api.core.auth.AuthService;
-import dev.donggi.core.api.core.auth.AuthorizationExtractor;
-import dev.donggi.core.api.core.domain.AuthenticatedMember;
-import dev.donggi.core.api.web.dto.LoginMember;
+import dev.donggi.core.api.core.member.auth.AuthService;
+import dev.donggi.core.api.core.member.auth.AuthorizationExtractor;
+import dev.donggi.core.api.core.member.domain.AuthenticatedMember;
+import dev.donggi.core.api.web.member.dto.LoginMember;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/MemberRepository.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/MemberRepository.java
@@ -1,7 +1,7 @@
-package dev.donggi.core.api.core;
+package dev.donggi.core.api.core.member;
 
-import dev.donggi.core.api.core.domain.Member;
-import dev.donggi.core.api.core.exception.MemberNotFoundException;
+import dev.donggi.core.api.core.member.domain.Member;
+import dev.donggi.core.api.core.member.exception.MemberNotFoundException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/MemberService.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/MemberService.java
@@ -1,8 +1,8 @@
-package dev.donggi.core.api.core;
+package dev.donggi.core.api.core.member;
 
-import dev.donggi.core.api.core.domain.Member;
-import dev.donggi.core.api.core.dto.MemberResponse;
-import dev.donggi.core.api.web.dto.LoginCommand;
+import dev.donggi.core.api.core.member.domain.Member;
+import dev.donggi.core.api.core.member.dto.MemberResponse;
+import dev.donggi.core.api.web.member.dto.LoginCommand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/AuthService.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/AuthService.java
@@ -1,8 +1,8 @@
-package dev.donggi.core.api.core.auth;
+package dev.donggi.core.api.core.member.auth;
 
-import dev.donggi.core.api.core.dto.AccessAndRefreshTokenResponse;
-import dev.donggi.core.api.core.dto.AuthToken;
-import dev.donggi.core.api.core.dto.MemberResponse;
+import dev.donggi.core.api.core.member.dto.AccessAndRefreshTokenResponse;
+import dev.donggi.core.api.core.member.dto.AuthToken;
+import dev.donggi.core.api.core.member.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/AuthTokenCreator.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/AuthTokenCreator.java
@@ -1,6 +1,6 @@
-package dev.donggi.core.api.core.auth;
+package dev.donggi.core.api.core.member.auth;
 
-import dev.donggi.core.api.core.dto.AuthToken;
+import dev.donggi.core.api.core.member.dto.AuthToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/AuthorizationExtractor.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/AuthorizationExtractor.java
@@ -1,7 +1,7 @@
-package dev.donggi.core.api.core.auth;
+package dev.donggi.core.api.core.member.auth;
 
-import dev.donggi.core.api.core.exception.EmptyAuthorizationHeaderException;
-import dev.donggi.core.api.core.exception.InvalidTokenException;
+import dev.donggi.core.api.core.member.exception.EmptyAuthorizationHeaderException;
+import dev.donggi.core.api.core.member.exception.InvalidTokenException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Objects;
 import org.springframework.http.HttpHeaders;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/JwtTokenProvider.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/JwtTokenProvider.java
@@ -1,6 +1,6 @@
-package dev.donggi.core.api.core.auth;
+package dev.donggi.core.api.core.member.auth;
 
-import dev.donggi.core.api.core.exception.InvalidTokenException;
+import dev.donggi.core.api.core.member.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/TokenProvider.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/auth/TokenProvider.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.auth;
+package dev.donggi.core.api.core.member.auth;
 
 public interface TokenProvider {
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/domain/AuthenticatedMember.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/domain/AuthenticatedMember.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.domain;
+package dev.donggi.core.api.core.member.domain;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/domain/Member.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/domain/Member.java
@@ -1,6 +1,6 @@
-package dev.donggi.core.api.core.domain;
+package dev.donggi.core.api.core.member.domain;
 
-import dev.donggi.core.api.core.exception.MemberInvalidPasswordException;
+import dev.donggi.core.api.core.member.exception.MemberInvalidPasswordException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/AccessAndRefreshTokenResponse.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/AccessAndRefreshTokenResponse.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.dto;
+package dev.donggi.core.api.core.member.dto;
 
 import lombok.Getter;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/AuthToken.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/AuthToken.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.dto;
+package dev.donggi.core.api.core.member.dto;
 
 import lombok.Getter;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/LoginResponse.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/LoginResponse.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.dto;
+package dev.donggi.core.api.core.member.dto;
 
 import lombok.Getter;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/MemberResponse.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/dto/MemberResponse.java
@@ -1,6 +1,6 @@
-package dev.donggi.core.api.core.dto;
+package dev.donggi.core.api.core.member.dto;
 
-import dev.donggi.core.api.core.domain.Member;
+import dev.donggi.core.api.core.member.domain.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/EmptyAuthorizationHeaderException.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/EmptyAuthorizationHeaderException.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.exception;
+package dev.donggi.core.api.core.member.exception;
 
 import dev.donggi.core.api.common.exception.ErrorCodeAndMessage;
 import dev.donggi.core.api.common.exception.GolrabaException;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/InvalidTokenException.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/InvalidTokenException.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.exception;
+package dev.donggi.core.api.core.member.exception;
 
 import dev.donggi.core.api.common.exception.ErrorCodeAndMessage;
 import dev.donggi.core.api.common.exception.GolrabaException;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/MemberInvalidPasswordException.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/MemberInvalidPasswordException.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.exception;
+package dev.donggi.core.api.core.member.exception;
 
 import dev.donggi.core.api.common.exception.ErrorCodeAndMessage;
 import dev.donggi.core.api.common.exception.GolrabaException;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/MemberNotFoundException.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/member/exception/MemberNotFoundException.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.core.exception;
+package dev.donggi.core.api.core.member.exception;
 
 import dev.donggi.core.api.common.exception.ErrorCodeAndMessage;
 import dev.donggi.core.api.common.exception.GolrabaException;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionFinder.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionFinder.java
@@ -1,0 +1,16 @@
+package dev.donggi.core.api.core.question;
+
+import dev.donggi.core.api.core.question.application.dto.QuestionDto;
+import dev.donggi.core.api.core.question.dto.QuestionPaginationDto;
+import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
+
+public interface AdminQuestionFinder {
+
+    /**
+     * 검색을 통해 질문을 조회합니다.
+     *
+     * @param content 검색할 content
+     * @return QuestionPaginationDto 페이징 처리가 된 Question 객체
+     */
+    QuestionPaginationDto searchByContent(String content, NoOffsetPageCommand pageCommand);
+}

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionJpaRepository.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionJpaRepository.java
@@ -1,0 +1,18 @@
+package dev.donggi.core.api.core.question;
+
+import dev.donggi.core.api.core.question.domain.Question;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AdminQuestionJpaRepository extends AdminQuestionRepository, JpaRepository<Question, Long> {
+
+    @Query(value = "select max(q.id) from Question q")
+    Optional<Long> findMaxId();
+
+    @Query(value = "select q from Question q where q.content.content like %:content% and q.id <= :searchAfterId order by q.id desc")
+    Slice<Question> findByContent(@Param("content") String content, @Param("searchAfterId") Long searchAfterId, Pageable ofSize);
+}

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionRepository.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionRepository.java
@@ -1,0 +1,26 @@
+package dev.donggi.core.api.core.question;
+
+import dev.donggi.core.api.core.question.domain.Question;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface AdminQuestionRepository {
+
+    /**
+     * 저장소에서 id의 최대값을 찾습니다.
+     *
+     * @return id 최대값
+     */
+    Optional<Long> findMaxId();
+
+    /**
+     * 저장소에서 검색 키워드를 통해 question 를 검색합니다.
+     *
+     * @param content 검색할 키워드
+     * @param searchAfterId 검색 기준 대상
+     * @param ofSize 페이지 크기
+     * @return 페이징 된 질문 객체
+     */
+    Slice<Question> findByContent(String content, Long searchAfterId, Pageable ofSize);
+}

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionService.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/AdminQuestionService.java
@@ -1,0 +1,42 @@
+package dev.donggi.core.api.core.question;
+
+import dev.donggi.core.api.core.comment.exception.NoOffsetPageInvalidException;
+import dev.donggi.core.api.core.question.application.dto.QuestionDto;
+import dev.donggi.core.api.core.question.dto.QuestionPaginationDto;
+import dev.donggi.core.api.core.question.domain.Question;
+import dev.donggi.core.api.core.question.domain.exception.QuestionNotFoundException;
+import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminQuestionService implements AdminQuestionFinder {
+
+    public static final Long QUESTION_PAGE_LIMIT_SIZE = 30L;
+
+    private final AdminQuestionRepository questionRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public QuestionPaginationDto searchByContent(String content, NoOffsetPageCommand pageCommand) {
+        checkNoOffsetPageSize(pageCommand.getSize());
+
+        Long searchAfterId = pageCommand.getSearchAfterId() == 0
+            ? questionRepository.findMaxId().orElse(0L)
+            : pageCommand.getSearchAfterId();
+
+        Slice<Question> sliceQuestions = questionRepository.findByContent(content, searchAfterId,
+            Pageable.ofSize(Math.toIntExact(pageCommand.getSize())));
+        return QuestionPaginationDto.ofEntity(sliceQuestions, content);
+    }
+
+    private void checkNoOffsetPageSize(Long size) {
+        if (size > QUESTION_PAGE_LIMIT_SIZE) {
+            throw new NoOffsetPageInvalidException();
+        }
+    }
+}

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/dto/QuestionPaginationDto.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/core/question/dto/QuestionPaginationDto.java
@@ -1,6 +1,7 @@
-package dev.donggi.core.api.core.question.application.dto;
+package dev.donggi.core.api.core.question.dto;
 
 import dev.donggi.core.api.core.common.PageDto;
+import dev.donggi.core.api.core.question.application.dto.QuestionDto;
 import dev.donggi.core.api.core.question.domain.Question;
 import java.util.ArrayList;
 import java.util.List;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/web/AdminQuestionRestController.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/web/AdminQuestionRestController.java
@@ -1,11 +1,11 @@
 package dev.donggi.core.api.web;
 
 import dev.donggi.core.api.common.response.ApiResponse;
-import dev.donggi.core.api.core.domain.AuthenticatedMember;
+import dev.donggi.core.api.core.member.domain.AuthenticatedMember;
 import dev.donggi.core.api.core.question.application.QuestionService;
 import dev.donggi.core.api.core.question.application.dto.QuestionDto;
 import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
-import dev.donggi.core.api.web.dto.LoginMember;
+import dev.donggi.core.api.web.member.dto.LoginMember;
 import dev.donggi.core.api.core.question.application.dto.QuestionPaginationDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
-public class AdminRestController {
+public class AdminQuestionRestController {
 
     private final QuestionService questionService;
 

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/web/member/MemberRestController.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/web/member/MemberRestController.java
@@ -1,11 +1,11 @@
-package dev.donggi.core.api.web;
+package dev.donggi.core.api.web.member;
 
-import dev.donggi.core.api.core.auth.AuthService;
-import dev.donggi.core.api.core.MemberService;
-import dev.donggi.core.api.core.dto.AccessAndRefreshTokenResponse;
-import dev.donggi.core.api.core.dto.LoginResponse;
-import dev.donggi.core.api.core.dto.MemberResponse;
-import dev.donggi.core.api.web.dto.LoginCommand;
+import dev.donggi.core.api.core.member.auth.AuthService;
+import dev.donggi.core.api.core.member.MemberService;
+import dev.donggi.core.api.core.member.dto.AccessAndRefreshTokenResponse;
+import dev.donggi.core.api.core.member.dto.LoginResponse;
+import dev.donggi.core.api.core.member.dto.MemberResponse;
+import dev.donggi.core.api.web.member.dto.LoginCommand;
 import dev.donggi.core.api.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/web/member/dto/LoginCommand.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/web/member/dto/LoginCommand.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.web.dto;
+package dev.donggi.core.api.web.member.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/web/member/dto/LoginMember.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/web/member/dto/LoginMember.java
@@ -1,4 +1,4 @@
-package dev.donggi.core.api.web.dto;
+package dev.donggi.core.api.web.member.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/admin/admin-api/src/main/java/dev/donggi/core/api/web/question/AdminQuestionRestController.java
+++ b/admin/admin-api/src/main/java/dev/donggi/core/api/web/question/AdminQuestionRestController.java
@@ -1,12 +1,13 @@
-package dev.donggi.core.api.web;
+package dev.donggi.core.api.web.question;
 
 import dev.donggi.core.api.common.response.ApiResponse;
 import dev.donggi.core.api.core.member.domain.AuthenticatedMember;
+import dev.donggi.core.api.core.question.AdminQuestionService;
 import dev.donggi.core.api.core.question.application.QuestionService;
 import dev.donggi.core.api.core.question.application.dto.QuestionDto;
 import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
 import dev.donggi.core.api.web.member.dto.LoginMember;
-import dev.donggi.core.api.core.question.application.dto.QuestionPaginationDto;
+import dev.donggi.core.api.core.question.dto.QuestionPaginationDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/admin")
 public class AdminQuestionRestController {
 
+    private final AdminQuestionService adminQuestionService;
     private final QuestionService questionService;
 
     @GetMapping("/question/{questionId}")
@@ -33,7 +35,7 @@ public class AdminQuestionRestController {
                                                               @RequestParam("content") String content,
                                                               @RequestParam(required = false, defaultValue = "0") String searchAfterId,
                                                               @RequestParam(required = false, defaultValue = "30") String size) {
-        QuestionPaginationDto question = questionService.searchByContent(content, new NoOffsetPageCommand(searchAfterId, size));
+        QuestionPaginationDto question = adminQuestionService.searchByContent(content, new NoOffsetPageCommand(searchAfterId, size));
         return ApiResponse.success(question);
     }
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/QuestionFinder.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/QuestionFinder.java
@@ -1,19 +1,9 @@
 package dev.donggi.core.api.core.question.application;
 
 import dev.donggi.core.api.core.question.application.dto.QuestionDto;
-import dev.donggi.core.api.core.question.application.dto.QuestionPaginationDto;
 import dev.donggi.core.api.core.question.application.dto.RandomQuestionsDto;
-import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
 
 public interface QuestionFinder {
-
-    /**
-     * 특정 카테고리의 질문을 무작위로 조회합니다.
-     *
-     * @param category 카테고리 이름
-     * @return RandomQuestionsDto 무작위로 조회한 여러 Question 이 포함된 객체
-     */
-    RandomQuestionsDto getRandomQuestionsByCategory(String category);
 
     /**
      * 특정 질문을 조회합니다.
@@ -24,10 +14,10 @@ public interface QuestionFinder {
     QuestionDto getQuestion(Long questionId);
 
     /**
-     * 검색을 통해 질문을 조회합니다.
+     * 특정 카테고리의 질문을 무작위로 조회합니다.
      *
-     * @param content 검색할 content
-     * @return QuestionPaginationDto 페이징 처리가 된 Question 객체
+     * @param category 카테고리 이름
+     * @return RandomQuestionsDto 무작위로 조회한 여러 Question 이 포함된 객체
      */
-    QuestionPaginationDto searchByContent(String content, NoOffsetPageCommand pageCommand);
+    RandomQuestionsDto getRandomQuestionsByCategory(String category);
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/QuestionService.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/application/QuestionService.java
@@ -1,8 +1,6 @@
 package dev.donggi.core.api.core.question.application;
 
-import dev.donggi.core.api.core.comment.exception.NoOffsetPageInvalidException;
 import dev.donggi.core.api.core.question.application.dto.QuestionDto;
-import dev.donggi.core.api.core.question.application.dto.QuestionPaginationDto;
 import dev.donggi.core.api.core.question.application.dto.RandomQuestionsDto;
 import dev.donggi.core.api.core.question.domain.Category;
 import dev.donggi.core.api.core.question.domain.Question;
@@ -11,15 +9,12 @@ import dev.donggi.core.api.core.question.domain.QuestionResult;
 import dev.donggi.core.api.core.question.domain.QuestionResultRepository;
 import dev.donggi.core.api.core.question.domain.exception.QuestionInvalidChoiceException;
 import dev.donggi.core.api.core.question.domain.exception.QuestionNotFoundException;
-import dev.donggi.core.api.web.comment.dto.NoOffsetPageCommand;
 import dev.donggi.core.api.web.question.dto.QuestionRegisterCommand;
 import dev.donggi.core.api.web.question.dto.QuestionResultCommand;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionService implements QuestionFinder, QuestionEditor {
 
     public static final int RANDOM_QUESTION_COUNT = 15;
-    public static final Long QUESTION_PAGE_LIMIT_SIZE = 30L;
     public static final String CHOICE_A = "a";
     public static final String CHOICE_B = "b";
 
@@ -105,25 +99,5 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
             .orElseThrow(QuestionNotFoundException::new);
 
         return QuestionDto.ofEntity(question, question.getQuestionResult());
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public QuestionPaginationDto searchByContent(String content, NoOffsetPageCommand pageCommand) {
-        checkNoOffsetPageSize(pageCommand.getSize());
-
-        Long searchAfterId = pageCommand.getSearchAfterId() == 0
-            ? questionRepository.findMaxId().orElse(0L)
-            : pageCommand.getSearchAfterId();
-
-        Slice<Question> sliceQuestions = questionRepository.findByContent(content, searchAfterId,
-            Pageable.ofSize(Math.toIntExact(pageCommand.getSize())));
-        return QuestionPaginationDto.ofEntity(sliceQuestions, content);
-    }
-
-    private void checkNoOffsetPageSize(Long size) {
-        if (size > QUESTION_PAGE_LIMIT_SIZE) {
-            throw new NoOffsetPageInvalidException();
-        }
     }
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/domain/QuestionRepository.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/domain/QuestionRepository.java
@@ -32,21 +32,4 @@ public interface QuestionRepository {
      * @return Optional<Question> 객체
      */
     Optional<Question> findById(Long questionId);
-
-    /**
-     * 저장소에서 id의 최대값을 찾습니다.
-     *
-     * @return id 최대값
-     */
-    Optional<Long> findMaxId();
-
-    /**
-     * 저장소에서 검색 키워드를 통해 question 를 검색합니다.
-     *
-     * @param content 검색할 키워드
-     * @param searchAfterId 검색 기준 대상
-     * @param ofSize 페이지 크기
-     * @return 페이징 된 질문 객체
-     */
-    Slice<Question> findByContent(String content, Long searchAfterId, Pageable ofSize);
 }

--- a/core/core-api/src/main/java/dev/donggi/core/api/core/question/infrastructure/QuestionJpaRepository.java
+++ b/core/core-api/src/main/java/dev/donggi/core/api/core/question/infrastructure/QuestionJpaRepository.java
@@ -14,10 +14,4 @@ public interface QuestionJpaRepository extends QuestionRepository, JpaRepository
 
     @Query(value = "select q.id from Question q where q.category in :categories")
     List<Long> findAllIdsByCategories(@Param("categories") List<String> categories);
-
-    @Query(value = "select max(q.id) from Question q")
-    Optional<Long> findMaxId();
-
-    @Query(value = "select q from Question q where q.content.content like %:content% and q.id <= :searchAfterId order by q.id desc")
-    Slice<Question> findByContent(@Param("content") String content, @Param("searchAfterId") Long searchAfterId, Pageable ofSize);
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

#79 

<br>

### 📝 구현 내용

- admin 모듈에서 사용하는 Question 검색 로직을 core 모듈에서 admin 모듈로 이동
