### PR TITLE
[feat] 카테고리와 active 상태에 맞는 질문 리스트 조회 API 추가

### DIFF
--- a/src/docs/asciidoc/question/question-read.adoc
+++ b/src/docs/asciidoc/question/question-read.adoc
@@ -1,4 +1,4 @@
-=== 카테고리 질문 조회
+=== 카테고리로 질문 id 리스트 조회
 
 API : `GET /api/golrabas/category/{category}`
 
@@ -28,7 +28,43 @@ include::{snippets}/questions-read-invalid-category/response-body.adoc[]
 ===== HTTP Response
 include::{snippets}/questions-read-invalid-category/http-response.adoc[]
 
-=== 특정 질문 조회
+=== 카테고리로 질문 리스트 조회
+
+API : `GET /api/golrabas/category/{category}/question`
+
+==== 성공
+===== Path Parameters
+include::{snippets}/question-list-read-by-category/path-parameters.adoc[]
+===== HTTP Request
+include::{snippets}/question-list-read-by-category/http-request.adoc[]
+
+==== Response
+===== Response Fields
+include::{snippets}/question-list-read-by-category/response-fields.adoc[]
+===== Response Body
+include::{snippets}/question-list-read-by-category/response-body.adoc[]
+===== HTTP Response
+include::{snippets}/question-list-read-by-category/http-response.adoc[]
+
+=== 카테고리와 active 상태에 맞는 질문 리스트 조회
+
+API : `GET /api/golrabas/category/{category}/question/active/{active}`
+
+==== 성공
+===== Path Parameters
+include::{snippets}/question-list-read-by-category-and-active/path-parameters.adoc[]
+===== HTTP Request
+include::{snippets}/question-list-read-by-category-and-active/http-request.adoc[]
+
+==== Response
+===== Response Fields
+include::{snippets}/question-list-read-by-category-and-active/response-fields.adoc[]
+===== Response Body
+include::{snippets}/question-list-read-by-category-and-active/response-body.adoc[]
+===== HTTP Response
+include::{snippets}/question-list-read-by-category-and-active/http-response.adoc[]
+
+=== 특정 질문 리조회
 
 API : `GET /api/golrabas/{questionId}`
 

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionFinder.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionFinder.java
@@ -30,7 +30,7 @@ public interface QuestionFinder {
      * @param noOffsetPageCommand 페이징 정보가 담긴 객체
      * @return 페이징된 질문 객체
      */
-    QuestionPaginationDto findAllBy(NoOffsetPageCommand noOffsetPageCommand);
+    QuestionPaginationDto findAllIdsByCategory(NoOffsetPageCommand noOffsetPageCommand);
 
     /**
      * 질문을 키워드로 검색하여 리스트로 조회합니다.
@@ -39,4 +39,21 @@ public interface QuestionFinder {
      * @return 페이징된 질문 객체
      */
     QuestionPaginationDto search(String keyword, NoOffsetPageCommand noOffsetPageCommand);
+
+    /**
+     * 어드민에서 카테고리로 질문 리스트를 조회합니다.
+     * @param category 조회할 카테고리
+     * @param pageCommand 페이징 정보가 담긴 객체
+     * @return 페이징된 질문 객체
+     */
+    QuestionPaginationDto findAllByCategory(Category category, NoOffsetPageCommand pageCommand);
+
+    /**
+     * 어드민에서 특정 active 상태의 카테고리 질문 리스트를 조회합니다.
+     * @param category 조회할 카테고리
+     * @param active 조회할 active 상태
+     * @param pageCommand 페이징 정보가 담긴 객체
+     * @return 페이징된 질문 객체
+     */
+    QuestionPaginationDto findAllByCategoryAndActive(Category category, boolean active, NoOffsetPageCommand pageCommand);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/application/QuestionService.java
@@ -129,7 +129,7 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
 
     @Override
     @Transactional(readOnly = true)
-    public QuestionPaginationDto findAllBy(NoOffsetPageCommand pageCommand) {
+    public QuestionPaginationDto findAllIdsByCategory(NoOffsetPageCommand pageCommand) {
         checkNoOffsetPageSize(pageCommand.getSize());
 
         Long searchAfterId = pageCommand.getSearchAfterId() == 0
@@ -152,6 +152,35 @@ public class QuestionService implements QuestionFinder, QuestionEditor {
             : pageCommand.getSearchAfterId();
 
         Slice<Question> sliceQuestions = questionRepository.findAllByContentContainingAndSearchAfterIdAndPageable(keyword, searchAfterId,
+            Pageable.ofSize(Math.toIntExact(pageCommand.getSize())));
+
+        return QuestionPaginationDto.ofEntity(sliceQuestions);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public QuestionPaginationDto findAllByCategory(Category category, NoOffsetPageCommand pageCommand) {
+        checkNoOffsetPageSize(pageCommand.getSize());
+
+        Long searchAfterId = pageCommand.getSearchAfterId() == 0
+            ? questionRepository.getMaxId()
+            : pageCommand.getSearchAfterId();
+
+        Slice<Question> sliceQuestions = questionRepository.findAllByCategoryAndSearchAfterIdAndPageable(category, searchAfterId,
+            Pageable.ofSize(Math.toIntExact(pageCommand.getSize())));
+
+        return QuestionPaginationDto.ofEntity(sliceQuestions);
+    }
+
+    @Override
+    public QuestionPaginationDto findAllByCategoryAndActive(Category category, boolean active, NoOffsetPageCommand pageCommand) {
+        checkNoOffsetPageSize(pageCommand.getSize());
+
+        Long searchAfterId = pageCommand.getSearchAfterId() == 0
+            ? questionRepository.getMaxId()
+            : pageCommand.getSearchAfterId();
+
+        Slice<Question> sliceQuestions = questionRepository.findAllByCategoryAndActiveAndSearchAfterIdAndPageable(category, active, searchAfterId,
             Pageable.ofSize(Math.toIntExact(pageCommand.getSize())));
 
         return QuestionPaginationDto.ofEntity(sliceQuestions);

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/domain/QuestionRepository.java
@@ -48,6 +48,15 @@ public interface QuestionRepository {
     Slice<Question> findAllBySearchAfterIdAndPageable(Long searchAfterId, Pageable ofSize);
 
     /**
+     * 카테고리로 저장소에서 질문 리스트를 검색 id 기준 이후의 페이지만큼 조회합니다.
+     * @param category 조회할 카테고리
+     * @param searchAfterId 검색 기준 대상
+     * @param ofSize 페이지 크기
+     * @return 페이징 된 질문 객체
+     */
+    Slice<Question> findAllByCategoryAndSearchAfterIdAndPageable(Category category, Long searchAfterId, Pageable ofSize);
+
+    /**
      * 저장소에서 질문을 키워드로 검색하고 페이지만큼 조회합니다.
      * @param keyword 검색할 키워드
      * @param searchAfterId 검색 기준 대상
@@ -62,4 +71,14 @@ public interface QuestionRepository {
      * @return 존재하면 true, 존재하지 않으면 false 반환
      */
     boolean existsById(Long questionId);
+
+    /**
+     * 저장소에서 특정 active 상태의 카테고리 질문 리스트를 조회합니다.
+     * @param category 조회할 카테고리
+     * @param active 조회할 active 상태
+     * @param searchAfterId 검색 기준 대상
+     * @param ofSize 페이지 크기
+     * @return 페이징 된 질문 객체
+     */
+    Slice<Question> findAllByCategoryAndActiveAndSearchAfterIdAndPageable(Category category, boolean active, Long searchAfterId, Pageable ofSize);
 }

--- a/src/main/java/donggi/dev/kkeuroolryo/core/question/infrastructure/QuestionJpaRepository.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/core/question/infrastructure/QuestionJpaRepository.java
@@ -26,6 +26,12 @@ public interface QuestionJpaRepository extends QuestionRepository, JpaRepository
     @Query(value = "select q from Question q where q.content.content like %:keyword% and q.id <= :searchAfterId order by q.id desc")
     Slice<Question> findAllByContentContainingAndSearchAfterIdAndPageable(@Param("keyword") String keyword, @Param("searchAfterId") Long searchAfterId, Pageable ofSize);
 
+    @Query(value = "select q from Question q where q.category = :category and q.id <= :searchAfterId order by q.id desc")
+    Slice<Question> findAllByCategoryAndSearchAfterIdAndPageable(@Param("category") Category category, @Param("searchAfterId") Long searchAfterId, Pageable ofSize);
+
+    @Query(value = "select q from Question q where q.category = :category and q.active = :active and q.id <= :searchAfterId order by q.id desc")
+    Slice<Question> findAllByCategoryAndActiveAndSearchAfterIdAndPageable(@Param("category") Category category, @Param("active") boolean active, @Param("searchAfterId") Long searchAfterId, Pageable ofSize);
+
     @Override
     default Question getById(Long questionId) {
         return findById(questionId).orElseThrow(QuestionNotFoundException::new);

--- a/src/main/java/donggi/dev/kkeuroolryo/web/question/QuestionRestController.java
+++ b/src/main/java/donggi/dev/kkeuroolryo/web/question/QuestionRestController.java
@@ -49,13 +49,40 @@ public class QuestionRestController {
     }
 
     /**
-     * 카테고리 이름으로 해당 카테고리의 질문을 조회합니다.
+     * 카테고리 이름으로 해당 카테고리의 질문 id를 조회합니다.
      * 질문은 랜덤한 순서로 조회합니다.
      */
     @GetMapping("/category/{category}")
-    public ApiResponse<RandomQuestionsDto> getQuestionsByCategory(@PathVariable("category") Category category) {
+    public ApiResponse<RandomQuestionsDto> getQuestionIdsByCategory(@PathVariable("category") Category category) {
         RandomQuestionsDto randomQuestionsDto = questionFinder.getRandomQuestionsByCategory(category);
         return ApiResponse.success(randomQuestionsDto);
+    }
+
+    /**
+     * 어드민에서 카테고리로 질문 리스트를 조회합니다.
+     */
+    @GetMapping("/category/{category}/question")
+    public ApiResponse<QuestionPaginationDto> getQuestionsByCategory(
+        @PathVariable("category") Category category,
+        @RequestParam(required = false, defaultValue = "0") String searchAfterId,
+        @RequestParam(required = false, defaultValue = "20") String size
+    ) {
+        QuestionPaginationDto questionPaginationDto = questionFinder.findAllByCategory(category, new NoOffsetPageCommand(searchAfterId, size));
+        return ApiResponse.success(questionPaginationDto);
+    }
+
+    /**
+     * 어드민에서 특정 active 상태의 카테고리 질문 리스트를 조회합니다.
+     */
+    @GetMapping("/category/{category}/question/active/{active}")
+    public ApiResponse<QuestionPaginationDto> getQuestionsByCategoryAndActive(
+        @PathVariable("category") Category category,
+        @PathVariable("active") boolean active,
+        @RequestParam(required = false, defaultValue = "0") String searchAfterId,
+        @RequestParam(required = false, defaultValue = "20") String size
+    ) {
+        QuestionPaginationDto questionPaginationDto = questionFinder.findAllByCategoryAndActive(category, active, new NoOffsetPageCommand(searchAfterId, size));
+        return ApiResponse.success(questionPaginationDto);
     }
 
     @GetMapping("/question/{questionId}")
@@ -69,7 +96,7 @@ public class QuestionRestController {
         @RequestParam(required = false, defaultValue = "0") String searchAfterId,
         @RequestParam(required = false, defaultValue = "20") String size
     ) {
-        QuestionPaginationDto questionPaginationDto = questionFinder.findAllBy(new NoOffsetPageCommand(searchAfterId, size));
+        QuestionPaginationDto questionPaginationDto = questionFinder.findAllIdsByCategory(new NoOffsetPageCommand(searchAfterId, size));
         return ApiResponse.success(questionPaginationDto);
     }
 

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -457,10 +457,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_질문_수정">1.2. 질문 수정</a></li>
 <li><a href="#_질문_상태_변경">1.3. 질문 상태 변경</a></li>
 <li><a href="#_질문_선택_결과_반영">1.4. 질문 선택 결과 반영</a></li>
-<li><a href="#_카테고리_질문_조회">1.5. 카테고리 질문 조회</a></li>
-<li><a href="#_특정_질문_조회">1.6. 특정 질문 조회</a></li>
-<li><a href="#_질문_리스트_조회">1.7. 질문 리스트 조회</a></li>
-<li><a href="#_질문_키워드_검색">1.8. 질문 키워드 검색</a></li>
+<li><a href="#_카테고리로_질문_id_리스트_조회">1.5. 카테고리로 질문 id 리스트 조회</a></li>
+<li><a href="#_카테고리로_질문_리스트_조회">1.6. 카테고리로 질문 리스트 조회</a></li>
+<li><a href="#_카테고리와_active_상태에_맞는_질문_리스트_조회">1.7. 카테고리와 active 상태에 맞는 질문 리스트 조회</a></li>
+<li><a href="#_특정_질문_조회">1.8. 특정 질문 조회</a></li>
+<li><a href="#_질문_리스트_조회">1.9. 질문 리스트 조회</a></li>
+<li><a href="#_질문_키워드_검색">1.10. 질문 키워드 검색</a></li>
 </ul>
 </li>
 <li><a href="#_댓글_api">2. 댓글 API</a>
@@ -537,7 +539,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/question HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 118
 
 {
@@ -624,7 +626,7 @@ Content-Length: 118
   "code" : "G001",
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
-    "id" : 135,
+    "id" : 167,
     "content" : "요청한 질문 본문",
     "active" : true,
     "choiceA" : "선택 A",
@@ -646,7 +648,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 290
@@ -655,7 +657,7 @@ Content-Length: 290
   "code" : "G001",
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
-    "id" : 135,
+    "id" : 167,
     "content" : "요청한 질문 본문",
     "active" : true,
     "choiceA" : "선택 A",
@@ -741,10 +743,10 @@ Content-Length: 290
 <h5 id="_http_request_2"><a class="link" href="#_http_request_2">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/golrabas/question/137 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/golrabas/question/169 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 118
 
 {
@@ -781,7 +783,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 104
@@ -833,10 +835,10 @@ Content-Length: 104
 <h5 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/golrabas/question/136/active/false HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/golrabas/question/168/active/false HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
@@ -865,7 +867,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 104
@@ -893,22 +895,22 @@ Content-Length: 104
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
   "results" : [ {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "b"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "b"
   } ]
 }</code></pre>
@@ -922,27 +924,27 @@ Content-Length: 104
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/result HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 320
 
 {
   "results" : [ {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "a"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "b"
   }, {
-    "questionId" : 138,
+    "questionId" : 170,
     "choice" : "b"
   } ]
 }</code></pre>
@@ -962,7 +964,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 104
@@ -978,7 +980,7 @@ Content-Length: 104
 </div>
 </div>
 <div class="sect2">
-<h3 id="_카테고리_질문_조회"><a class="link" href="#_카테고리_질문_조회">1.5. 카테고리 질문 조회</a></h3>
+<h3 id="_카테고리로_질문_id_리스트_조회"><a class="link" href="#_카테고리로_질문_id_리스트_조회">1.5. 카테고리로 질문 id 리스트 조회</a></h3>
 <div class="paragraph">
 <p>API : <code>GET /api/golrabas/category/{category}</code></p>
 </div>
@@ -1013,7 +1015,7 @@ Content-Length: 104
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/SELF HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
@@ -1068,7 +1070,7 @@ Host: localhost:60147</code></pre>
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
     "category" : "SELF",
-    "questionIds" : [ 56, 57, 55, 59, 60, 63, 58, 62, 68, 64, 54, 61, 67, 69, 65 ]
+    "questionIds" : [ 63, 61, 57, 65, 60, 62, 68, 56, 59, 64, 67, 58, 54, 69, 66 ]
   }
 }</code></pre>
 </div>
@@ -1084,7 +1086,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 213
@@ -1094,7 +1096,7 @@ Content-Length: 213
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
     "category" : "SELF",
-    "questionIds" : [ 56, 57, 55, 59, 60, 63, 58, 62, 68, 64, 54, 61, 67, 69, 65 ]
+    "questionIds" : [ 63, 61, 57, 65, 60, 62, 68, 56, 59, 64, 67, 58, 54, 69, 66 ]
   }
 }</code></pre>
 </div>
@@ -1132,7 +1134,7 @@ Content-Length: 213
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/haha HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
@@ -1161,7 +1163,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Connection: close
 Content-Length: 400
 
@@ -1176,16 +1178,16 @@ Content-Length: 400
 </div>
 </div>
 <div class="sect2">
-<h3 id="_특정_질문_조회"><a class="link" href="#_특정_질문_조회">1.6. 특정 질문 조회</a></h3>
+<h3 id="_카테고리로_질문_리스트_조회"><a class="link" href="#_카테고리로_질문_리스트_조회">1.6. 카테고리로 질문 리스트 조회</a></h3>
 <div class="paragraph">
-<p>API : <code>GET /api/golrabas/{questionId}</code></p>
+<p>API : <code>GET /api/golrabas/category/{category}/question</code></p>
 </div>
 <div class="sect3">
 <h4 id="_성공_2"><a class="link" href="#_성공_2">1.6.1. 성공</a></h4>
 <div class="sect4">
 <h5 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">Path Parameters</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 5. /api/golrabas/question/{questionId}</caption>
+<caption class="title">Table 5. /api/golrabas/category/{category}/question</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1198,8 +1200,8 @@ Content-Length: 400
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 카테고리</p></td>
 </tr>
 </tbody>
 </table>
@@ -1208,10 +1210,10 @@ Content-Length: 400
 <h5 id="_http_request_7"><a class="link" href="#_http_request_7">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question/85 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/SELF/question?searchAfterId=101&amp;size=5 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
@@ -1245,39 +1247,54 @@ Host: localhost:60147</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">응답 메세지</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].id</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].content</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">질문 본문</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceA</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceA</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">선택지 A</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceB</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceB</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">선택지 B</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.active</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].active</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">활성화 상태</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceAResult</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceAResult</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">선택지 A의 득표율</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceBResult</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceBResult</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">선택지 B의 득표율</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.page.size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회된 데이터 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.page.nextId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 데이터 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.page.last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -1290,13 +1307,52 @@ Host: localhost:60147</code></pre>
   "code" : "G001",
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
-    "id" : 85,
-    "content" : "질문 본문16",
-    "active" : true,
-    "choiceA" : "선택A 16",
-    "choiceB" : "선택B 16",
-    "choiceAResult" : 0,
-    "choiceBResult" : 0
+    "questions" : [ {
+      "id" : 101,
+      "content" : "질문 본문16",
+      "active" : true,
+      "choiceA" : "선택A 16",
+      "choiceB" : "선택B 16",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 100,
+      "content" : "질문 본문15",
+      "active" : true,
+      "choiceA" : "선택A 15",
+      "choiceB" : "선택B 15",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 99,
+      "content" : "질문 본문14",
+      "active" : true,
+      "choiceA" : "선택A 14",
+      "choiceB" : "선택B 14",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 98,
+      "content" : "질문 본문13",
+      "active" : true,
+      "choiceA" : "선택A 13",
+      "choiceB" : "선택B 13",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 97,
+      "content" : "질문 본문12",
+      "active" : true,
+      "choiceA" : "선택A 12",
+      "choiceB" : "선택B 12",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    } ],
+    "page" : {
+      "size" : 5,
+      "nextId" : 97,
+      "last" : false
+    }
   }
 }</code></pre>
 </div>
@@ -1312,34 +1368,79 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 285
+Content-Length: 1225
 
 {
   "code" : "G001",
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
-    "id" : 85,
-    "content" : "질문 본문16",
-    "active" : true,
-    "choiceA" : "선택A 16",
-    "choiceB" : "선택B 16",
-    "choiceAResult" : 0,
-    "choiceBResult" : 0
+    "questions" : [ {
+      "id" : 101,
+      "content" : "질문 본문16",
+      "active" : true,
+      "choiceA" : "선택A 16",
+      "choiceB" : "선택B 16",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 100,
+      "content" : "질문 본문15",
+      "active" : true,
+      "choiceA" : "선택A 15",
+      "choiceB" : "선택B 15",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 99,
+      "content" : "질문 본문14",
+      "active" : true,
+      "choiceA" : "선택A 14",
+      "choiceB" : "선택B 14",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 98,
+      "content" : "질문 본문13",
+      "active" : true,
+      "choiceA" : "선택A 13",
+      "choiceB" : "선택B 13",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 97,
+      "content" : "질문 본문12",
+      "active" : true,
+      "choiceA" : "선택A 12",
+      "choiceB" : "선택B 12",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    } ],
+    "page" : {
+      "size" : 5,
+      "nextId" : 97,
+      "last" : false
+    }
   }
 }</code></pre>
 </div>
 </div>
 </div>
 </div>
+</div>
+<div class="sect2">
+<h3 id="_카테고리와_active_상태에_맞는_질문_리스트_조회"><a class="link" href="#_카테고리와_active_상태에_맞는_질문_리스트_조회">1.7. 카테고리와 active 상태에 맞는 질문 리스트 조회</a></h3>
+<div class="paragraph">
+<p>API : <code>GET /api/golrabas/category/{category}/question/active/{active}</code></p>
+</div>
 <div class="sect3">
-<h4 id="_실패_2"><a class="link" href="#_실패_2">1.6.3. 실패</a></h4>
+<h4 id="_성공_3"><a class="link" href="#_성공_3">1.7.1. 성공</a></h4>
 <div class="sect4">
 <h5 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">Path Parameters</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /api/golrabas/question/{questionId}</caption>
+<caption class="title">Table 6. /api/golrabas/category/{category}/question/active/{active}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1352,8 +1453,12 @@ Content-Length: 285
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>category</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 카테고리</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>active</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 active 상태</p></td>
 </tr>
 </tbody>
 </table>
@@ -1362,98 +1467,16 @@ Content-Length: 285
 <h5 id="_http_request_8"><a class="link" href="#_http_request_8">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question/-1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/category/SELF/question/active/true?searchAfterId=133&amp;size=5 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_8"><a class="link" href="#_response_8">1.6.4. Response</a></h4>
-<div class="sect4">
-<h5 id="_response_body_7"><a class="link" href="#_response_body_7">Response Body</a></h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
-  "code" : "Q404",
-  "message" : "존재하지 않는 질문입니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_http_response_8"><a class="link" href="#_http_response_8">HTTP Response</a></h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json
-Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
-Connection: close
-Content-Length: 92
-
-{
-  "code" : "Q404",
-  "message" : "존재하지 않는 질문입니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_질문_리스트_조회"><a class="link" href="#_질문_리스트_조회">1.7. 질문 리스트 조회</a></h3>
-<div class="paragraph">
-<p>API : <code>GET /api/golrabas/question</code></p>
-</div>
-<div class="sect3">
-<h4 id="_성공_3"><a class="link" href="#_성공_3">1.7.1. 성공</a></h4>
-<div class="sect4">
-<h5 id="_http_request_9"><a class="link" href="#_http_request_9">HTTP Request</a></h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question?searchAfterId=101&amp;size=5 HTTP/1.1
-Accept: application/json
-Content-Type: application/json
-Host: localhost:60147</code></pre>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_query_parameters"><a class="link" href="#_query_parameters">Query Parameters</a></h5>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>searchAfterId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">검색 시작할 댓글 id</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 데이터 개수</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_9"><a class="link" href="#_response_9">1.7.2. Response</a></h4>
+<h4 id="_response_8"><a class="link" href="#_response_8">1.7.2. Response</a></h4>
 <div class="sect4">
 <h5 id="_response_fields_4"><a class="link" href="#_response_fields_4">Response Fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
@@ -1534,7 +1557,7 @@ Host: localhost:60147</code></pre>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_response_body_8"><a class="link" href="#_response_body_8">Response Body</a></h5>
+<h5 id="_response_body_7"><a class="link" href="#_response_body_7">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -1542,7 +1565,7 @@ Host: localhost:60147</code></pre>
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
     "questions" : [ {
-      "id" : 101,
+      "id" : 133,
       "content" : "질문 본문16",
       "active" : true,
       "choiceA" : "선택A 16",
@@ -1550,7 +1573,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 100,
+      "id" : 132,
       "content" : "질문 본문15",
       "active" : true,
       "choiceA" : "선택A 15",
@@ -1558,7 +1581,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 99,
+      "id" : 131,
       "content" : "질문 본문14",
       "active" : true,
       "choiceA" : "선택A 14",
@@ -1566,7 +1589,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 98,
+      "id" : 130,
       "content" : "질문 본문13",
       "active" : true,
       "choiceA" : "선택A 13",
@@ -1574,7 +1597,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 97,
+      "id" : 129,
       "content" : "질문 본문12",
       "active" : true,
       "choiceA" : "선택A 12",
@@ -1584,9 +1607,208 @@ Host: localhost:60147</code></pre>
     } ],
     "page" : {
       "size" : 5,
-      "nextId" : 97,
+      "nextId" : 129,
       "last" : false
     }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_http_response_8"><a class="link" href="#_http_response_8">HTTP Response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Transfer-Encoding: chunked
+Date: Sun, 08 Oct 2023 16:55:18 GMT
+Keep-Alive: timeout=60
+Connection: keep-alive
+Content-Length: 1229
+
+{
+  "code" : "G001",
+  "message" : "요청이 정상적으로 처리되었습니다.",
+  "data" : {
+    "questions" : [ {
+      "id" : 133,
+      "content" : "질문 본문16",
+      "active" : true,
+      "choiceA" : "선택A 16",
+      "choiceB" : "선택B 16",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 132,
+      "content" : "질문 본문15",
+      "active" : true,
+      "choiceA" : "선택A 15",
+      "choiceB" : "선택B 15",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 131,
+      "content" : "질문 본문14",
+      "active" : true,
+      "choiceA" : "선택A 14",
+      "choiceB" : "선택B 14",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 130,
+      "content" : "질문 본문13",
+      "active" : true,
+      "choiceA" : "선택A 13",
+      "choiceB" : "선택B 13",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 129,
+      "content" : "질문 본문12",
+      "active" : true,
+      "choiceA" : "선택A 12",
+      "choiceB" : "선택B 12",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    } ],
+    "page" : {
+      "size" : 5,
+      "nextId" : 129,
+      "last" : false
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_특정_질문_조회"><a class="link" href="#_특정_질문_조회">1.8. 특정 질문 조회</a></h3>
+<div class="paragraph">
+<p>API : <code>GET /api/golrabas/{questionId}</code></p>
+</div>
+<div class="sect3">
+<h4 id="_성공_4"><a class="link" href="#_성공_4">1.8.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_path_parameters_7"><a class="link" href="#_path_parameters_7">Path Parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 7. /api/golrabas/question/{questionId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_http_request_9"><a class="link" href="#_http_request_9">HTTP Request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question/85 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Host: localhost:59907</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_9"><a class="link" href="#_response_9">1.8.2. Response</a></h4>
+<div class="sect4">
+<h5 id="_response_fields_5"><a class="link" href="#_response_fields_5">Response Fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 본문</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceA</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 A</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceB</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 B</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.active</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">활성화 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceAResult</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 A의 득표율</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.choiceBResult</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 B의 득표율</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_response_body_8"><a class="link" href="#_response_body_8">Response Body</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "code" : "G001",
+  "message" : "요청이 정상적으로 처리되었습니다.",
+  "data" : {
+    "id" : 85,
+    "content" : "질문 본문16",
+    "active" : true,
+    "choiceA" : "선택A 16",
+    "choiceB" : "선택B 16",
+    "choiceAResult" : 0,
+    "choiceBResult" : 0
   }
 }</code></pre>
 </div>
@@ -1602,62 +1824,96 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
-Content-Length: 1225
+Content-Length: 285
 
 {
   "code" : "G001",
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
-    "questions" : [ {
-      "id" : 101,
-      "content" : "질문 본문16",
-      "active" : true,
-      "choiceA" : "선택A 16",
-      "choiceB" : "선택B 16",
-      "choiceAResult" : 0,
-      "choiceBResult" : 0
-    }, {
-      "id" : 100,
-      "content" : "질문 본문15",
-      "active" : true,
-      "choiceA" : "선택A 15",
-      "choiceB" : "선택B 15",
-      "choiceAResult" : 0,
-      "choiceBResult" : 0
-    }, {
-      "id" : 99,
-      "content" : "질문 본문14",
-      "active" : true,
-      "choiceA" : "선택A 14",
-      "choiceB" : "선택B 14",
-      "choiceAResult" : 0,
-      "choiceBResult" : 0
-    }, {
-      "id" : 98,
-      "content" : "질문 본문13",
-      "active" : true,
-      "choiceA" : "선택A 13",
-      "choiceB" : "선택B 13",
-      "choiceAResult" : 0,
-      "choiceBResult" : 0
-    }, {
-      "id" : 97,
-      "content" : "질문 본문12",
-      "active" : true,
-      "choiceA" : "선택A 12",
-      "choiceB" : "선택B 12",
-      "choiceAResult" : 0,
-      "choiceBResult" : 0
-    } ],
-    "page" : {
-      "size" : 5,
-      "nextId" : 97,
-      "last" : false
-    }
+    "id" : 85,
+    "content" : "질문 본문16",
+    "active" : true,
+    "choiceA" : "선택A 16",
+    "choiceB" : "선택B 16",
+    "choiceAResult" : 0,
+    "choiceBResult" : 0
   }
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_실패_2"><a class="link" href="#_실패_2">1.8.3. 실패</a></h4>
+<div class="sect4">
+<h5 id="_path_parameters_8"><a class="link" href="#_path_parameters_8">Path Parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 8. /api/golrabas/question/{questionId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>questionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_http_request_10"><a class="link" href="#_http_request_10">HTTP Request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question/-1 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Host: localhost:59907</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_10"><a class="link" href="#_response_10">1.8.4. Response</a></h4>
+<div class="sect4">
+<h5 id="_response_body_9"><a class="link" href="#_response_body_9">Response Body</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "code" : "Q404",
+  "message" : "존재하지 않는 질문입니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_http_response_10"><a class="link" href="#_http_response_10">HTTP Response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Transfer-Encoding: chunked
+Date: Sun, 08 Oct 2023 16:55:18 GMT
+Connection: close
+Content-Length: 92
+
+{
+  "code" : "Q404",
+  "message" : "존재하지 않는 질문입니다.",
+  "data" : null
 }</code></pre>
 </div>
 </div>
@@ -1665,25 +1921,25 @@ Content-Length: 1225
 </div>
 </div>
 <div class="sect2">
-<h3 id="_질문_키워드_검색"><a class="link" href="#_질문_키워드_검색">1.8. 질문 키워드 검색</a></h3>
+<h3 id="_질문_리스트_조회"><a class="link" href="#_질문_리스트_조회">1.9. 질문 리스트 조회</a></h3>
 <div class="paragraph">
-<p>API : <code>GET /api/golrabas/question/search</code></p>
+<p>API : <code>GET /api/golrabas/question</code></p>
 </div>
 <div class="sect3">
-<h4 id="_성공_4"><a class="link" href="#_성공_4">1.8.1. 성공</a></h4>
+<h4 id="_성공_5"><a class="link" href="#_성공_5">1.9.1. 성공</a></h4>
 <div class="sect4">
-<h5 id="_http_request_10"><a class="link" href="#_http_request_10">HTTP Request</a></h5>
+<h5 id="_http_request_11"><a class="link" href="#_http_request_11">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question/search?keyword=%EC%A7%88%EB%AC%B8&amp;searchAfterId=133&amp;size=5 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question?searchAfterId=117&amp;size=5 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">Query Parameters</a></h5>
+<h5 id="_query_parameters"><a class="link" href="#_query_parameters">Query Parameters</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1697,10 +1953,6 @@ Host: localhost:60147</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keyword</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">검색할 질문 키워드</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>searchAfterId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">검색 시작할 댓글 id</p></td>
 </tr>
@@ -1713,9 +1965,9 @@ Host: localhost:60147</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_10"><a class="link" href="#_response_10">1.8.2. Response</a></h4>
+<h4 id="_response_11"><a class="link" href="#_response_11">1.9.2. Response</a></h4>
 <div class="sect4">
-<h5 id="_response_fields_5"><a class="link" href="#_response_fields_5">Response Fields</a></h5>
+<h5 id="_response_fields_6"><a class="link" href="#_response_fields_6">Response Fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1794,7 +2046,7 @@ Host: localhost:60147</code></pre>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_response_body_9"><a class="link" href="#_response_body_9">Response Body</a></h5>
+<h5 id="_response_body_10"><a class="link" href="#_response_body_10">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -1802,7 +2054,7 @@ Host: localhost:60147</code></pre>
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
     "questions" : [ {
-      "id" : 133,
+      "id" : 117,
       "content" : "질문 본문16",
       "active" : true,
       "choiceA" : "선택A 16",
@@ -1810,7 +2062,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 132,
+      "id" : 116,
       "content" : "질문 본문15",
       "active" : true,
       "choiceA" : "선택A 15",
@@ -1818,7 +2070,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 131,
+      "id" : 115,
       "content" : "질문 본문14",
       "active" : true,
       "choiceA" : "선택A 14",
@@ -1826,7 +2078,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 130,
+      "id" : 114,
       "content" : "질문 본문13",
       "active" : true,
       "choiceA" : "선택A 13",
@@ -1834,7 +2086,7 @@ Host: localhost:60147</code></pre>
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 129,
+      "id" : 113,
       "content" : "질문 본문12",
       "active" : true,
       "choiceA" : "선택A 12",
@@ -1844,7 +2096,7 @@ Host: localhost:60147</code></pre>
     } ],
     "page" : {
       "size" : 5,
-      "nextId" : 129,
+      "nextId" : 113,
       "last" : false
     }
   }
@@ -1853,7 +2105,7 @@ Host: localhost:60147</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_http_response_10"><a class="link" href="#_http_response_10">HTTP Response</a></h5>
+<h5 id="_http_response_11"><a class="link" href="#_http_response_11">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1862,7 +2114,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 1229
@@ -1872,7 +2124,7 @@ Content-Length: 1229
   "message" : "요청이 정상적으로 처리되었습니다.",
   "data" : {
     "questions" : [ {
-      "id" : 133,
+      "id" : 117,
       "content" : "질문 본문16",
       "active" : true,
       "choiceA" : "선택A 16",
@@ -1880,7 +2132,7 @@ Content-Length: 1229
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 132,
+      "id" : 116,
       "content" : "질문 본문15",
       "active" : true,
       "choiceA" : "선택A 15",
@@ -1888,7 +2140,7 @@ Content-Length: 1229
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 131,
+      "id" : 115,
       "content" : "질문 본문14",
       "active" : true,
       "choiceA" : "선택A 14",
@@ -1896,7 +2148,7 @@ Content-Length: 1229
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 130,
+      "id" : 114,
       "content" : "질문 본문13",
       "active" : true,
       "choiceA" : "선택A 13",
@@ -1904,7 +2156,7 @@ Content-Length: 1229
       "choiceAResult" : 0,
       "choiceBResult" : 0
     }, {
-      "id" : 129,
+      "id" : 113,
       "content" : "질문 본문12",
       "active" : true,
       "choiceA" : "선택A 12",
@@ -1914,7 +2166,267 @@ Content-Length: 1229
     } ],
     "page" : {
       "size" : 5,
-      "nextId" : 129,
+      "nextId" : 113,
+      "last" : false
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_질문_키워드_검색"><a class="link" href="#_질문_키워드_검색">1.10. 질문 키워드 검색</a></h3>
+<div class="paragraph">
+<p>API : <code>GET /api/golrabas/question/search</code></p>
+</div>
+<div class="sect3">
+<h4 id="_성공_6"><a class="link" href="#_성공_6">1.10.1. 성공</a></h4>
+<div class="sect4">
+<h5 id="_http_request_12"><a class="link" href="#_http_request_12">HTTP Request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/question/search?keyword=%EC%A7%88%EB%AC%B8&amp;searchAfterId=165&amp;size=5 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Host: localhost:59907</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">Query Parameters</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>keyword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색할 질문 키워드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>searchAfterId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검색 시작할 댓글 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 데이터 개수</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_12"><a class="link" href="#_response_12">1.10.2. Response</a></h4>
+<div class="sect4">
+<h5 id="_response_fields_7"><a class="link" href="#_response_fields_7">Response Fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">질문 본문</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceA</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 A</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceB</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 B</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].active</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">활성화 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceAResult</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 A의 득표율</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.questions[].choiceBResult</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선택지 B의 득표율</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.page.size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회된 데이터 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.page.nextId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 데이터 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.page.last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_response_body_11"><a class="link" href="#_response_body_11">Response Body</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "code" : "G001",
+  "message" : "요청이 정상적으로 처리되었습니다.",
+  "data" : {
+    "questions" : [ {
+      "id" : 165,
+      "content" : "질문 본문16",
+      "active" : true,
+      "choiceA" : "선택A 16",
+      "choiceB" : "선택B 16",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 164,
+      "content" : "질문 본문15",
+      "active" : true,
+      "choiceA" : "선택A 15",
+      "choiceB" : "선택B 15",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 163,
+      "content" : "질문 본문14",
+      "active" : true,
+      "choiceA" : "선택A 14",
+      "choiceB" : "선택B 14",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 162,
+      "content" : "질문 본문13",
+      "active" : true,
+      "choiceA" : "선택A 13",
+      "choiceB" : "선택B 13",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 161,
+      "content" : "질문 본문12",
+      "active" : true,
+      "choiceA" : "선택A 12",
+      "choiceB" : "선택B 12",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    } ],
+    "page" : {
+      "size" : 5,
+      "nextId" : 161,
+      "last" : false
+    }
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_http_response_12"><a class="link" href="#_http_response_12">HTTP Response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Transfer-Encoding: chunked
+Date: Sun, 08 Oct 2023 16:55:18 GMT
+Keep-Alive: timeout=60
+Connection: keep-alive
+Content-Length: 1229
+
+{
+  "code" : "G001",
+  "message" : "요청이 정상적으로 처리되었습니다.",
+  "data" : {
+    "questions" : [ {
+      "id" : 165,
+      "content" : "질문 본문16",
+      "active" : true,
+      "choiceA" : "선택A 16",
+      "choiceB" : "선택B 16",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 164,
+      "content" : "질문 본문15",
+      "active" : true,
+      "choiceA" : "선택A 15",
+      "choiceB" : "선택B 15",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 163,
+      "content" : "질문 본문14",
+      "active" : true,
+      "choiceA" : "선택A 14",
+      "choiceB" : "선택B 14",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 162,
+      "content" : "질문 본문13",
+      "active" : true,
+      "choiceA" : "선택A 13",
+      "choiceB" : "선택B 13",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    }, {
+      "id" : 161,
+      "content" : "질문 본문12",
+      "active" : true,
+      "choiceA" : "선택A 12",
+      "choiceB" : "선택B 12",
+      "choiceAResult" : 0,
+      "choiceBResult" : 0
+    } ],
+    "page" : {
+      "size" : 5,
+      "nextId" : 161,
       "last" : false
     }
   }
@@ -1935,11 +2447,11 @@ Content-Length: 1229
 <p>API : <code>POST /api/golrabas/{questionId}/comments</code></p>
 </div>
 <div class="sect3">
-<h4 id="_성공_5"><a class="link" href="#_성공_5">2.1.1. 성공</a></h4>
+<h4 id="_성공_7"><a class="link" href="#_성공_7">2.1.1. 성공</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter"><a class="link" href="#_path_parameter">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 7. /api/golrabas/{questionId}/comments</caption>
+<caption class="title">Table 9. /api/golrabas/{questionId}/comments</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1993,13 +2505,13 @@ Content-Length: 1229
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_11"><a class="link" href="#_http_request_11">HTTP Request</a></h5>
+<h5 id="_http_request_13"><a class="link" href="#_http_request_13">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/37/comments HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 98
 
 {
@@ -2011,7 +2523,7 @@ Content-Length: 98
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_fields_6"><a class="link" href="#_response_fields_6">Response Fields</a></h5>
+<h5 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2055,7 +2567,7 @@ Content-Length: 98
 </table>
 </div>
 <div class="sect4">
-<h5 id="_response_body_10"><a class="link" href="#_response_body_10">Response Body</a></h5>
+<h5 id="_response_body_12"><a class="link" href="#_response_body_12">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -2071,7 +2583,7 @@ Content-Length: 98
 </div>
 </div>
 <div class="sect4">
-<h5 id="_http_response_11"><a class="link" href="#_http_response_11">HTTP Response</a></h5>
+<h5 id="_http_response_13"><a class="link" href="#_http_response_13">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2080,7 +2592,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 185
@@ -2103,7 +2615,7 @@ Content-Length: 185
 <div class="sect4">
 <h5 id="_path_parameter_2"><a class="link" href="#_path_parameter_2">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 8. /api/golrabas/{questionId}/comments</caption>
+<caption class="title">Table 10. /api/golrabas/{questionId}/comments</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2157,13 +2669,13 @@ Content-Length: 185
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_12"><a class="link" href="#_http_request_12">HTTP Request</a></h5>
+<h5 id="_http_request_14"><a class="link" href="#_http_request_14">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/33/comments HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 86
 
 {
@@ -2175,7 +2687,7 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_body_11"><a class="link" href="#_response_body_11">Response Body</a></h5>
+<h5 id="_response_body_13"><a class="link" href="#_response_body_13">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -2187,7 +2699,7 @@ Content-Length: 86
 </div>
 </div>
 <div class="sect4">
-<h5 id="_http_response_12"><a class="link" href="#_http_response_12">HTTP Response</a></h5>
+<h5 id="_http_response_14"><a class="link" href="#_http_response_14">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
@@ -2196,7 +2708,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Connection: close
 Content-Length: 95
 
@@ -2216,11 +2728,11 @@ Content-Length: 95
 <p>API : <code>PUT /api/golrabas/{questionId}/comments/{commentId}</code></p>
 </div>
 <div class="sect3">
-<h4 id="_성공_6"><a class="link" href="#_성공_6">2.2.1. 성공</a></h4>
+<h4 id="_성공_8"><a class="link" href="#_성공_8">2.2.1. 성공</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter_3"><a class="link" href="#_path_parameter_3">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. /api/golrabas/{questionId}/comments/{commentId}</caption>
+<caption class="title">Table 11. /api/golrabas/{questionId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2278,13 +2790,13 @@ Content-Length: 95
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_13"><a class="link" href="#_http_request_13">HTTP Request</a></h5>
+<h5 id="_http_request_15"><a class="link" href="#_http_request_15">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/golrabas/36/comments/21 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 81
 
 {
@@ -2296,7 +2808,7 @@ Content-Length: 81
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response_body_12"><a class="link" href="#_response_body_12">Response Body</a></h5>
+<h5 id="_response_body_14"><a class="link" href="#_response_body_14">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -2308,7 +2820,7 @@ Content-Length: 81
 </div>
 </div>
 <div class="sect4">
-<h5 id="_http_response_13"><a class="link" href="#_http_response_13">HTTP Response</a></h5>
+<h5 id="_http_response_15"><a class="link" href="#_http_response_15">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2317,7 +2829,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 104
@@ -2338,11 +2850,11 @@ Content-Length: 104
 <p>API : <code>DELETE /api/golrabas/{questionId}/comments/{commentsId}</code></p>
 </div>
 <div class="sect3">
-<h4 id="_성공_7"><a class="link" href="#_성공_7">2.3.1. 성공</a></h4>
+<h4 id="_성공_9"><a class="link" href="#_성공_9">2.3.1. 성공</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter_4"><a class="link" href="#_path_parameter_4">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. /api/golrabas/{questionId}/comments/{commentId}</caption>
+<caption class="title">Table 12. /api/golrabas/{questionId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2390,13 +2902,13 @@ Content-Length: 104
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_14"><a class="link" href="#_http_request_14">HTTP Request</a></h5>
+<h5 id="_http_request_16"><a class="link" href="#_http_request_16">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/golrabas/34/comments/19 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 36
 
 {
@@ -2407,9 +2919,9 @@ Content-Length: 36
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_11"><a class="link" href="#_response_11">2.3.2. Response</a></h4>
+<h4 id="_response_13"><a class="link" href="#_response_13">2.3.2. Response</a></h4>
 <div class="sect4">
-<h5 id="_http_response_14"><a class="link" href="#_http_response_14">HTTP Response</a></h5>
+<h5 id="_http_response_16"><a class="link" href="#_http_response_16">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2418,7 +2930,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 104
@@ -2437,7 +2949,7 @@ Content-Length: 104
 <div class="sect4">
 <h5 id="_path_parameter_5"><a class="link" href="#_path_parameter_5">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. /api/golrabas/{questionId}/comments/{commentId}</caption>
+<caption class="title">Table 13. /api/golrabas/{questionId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2485,13 +2997,13 @@ Content-Length: 104
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_15"><a class="link" href="#_http_request_15">HTTP Request</a></h5>
+<h5 id="_http_request_17"><a class="link" href="#_http_request_17">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/golrabas/31/comments/-1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 36
 
 {
@@ -2502,9 +3014,9 @@ Content-Length: 36
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_12"><a class="link" href="#_response_12">2.3.4. Response</a></h4>
+<h4 id="_response_14"><a class="link" href="#_response_14">2.3.4. Response</a></h4>
 <div class="sect4">
-<h5 id="_http_response_15"><a class="link" href="#_http_response_15">HTTP Response</a></h5>
+<h5 id="_http_response_17"><a class="link" href="#_http_response_17">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
@@ -2513,7 +3025,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Connection: close
 Content-Length: 92
 
@@ -2531,7 +3043,7 @@ Content-Length: 92
 <div class="sect4">
 <h5 id="_path_parameter_6"><a class="link" href="#_path_parameter_6">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. /api/golrabas/{questionId}/comments/{commentId}</caption>
+<caption class="title">Table 14. /api/golrabas/{questionId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2579,13 +3091,13 @@ Content-Length: 92
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_16"><a class="link" href="#_http_request_16">HTTP Request</a></h5>
+<h5 id="_http_request_18"><a class="link" href="#_http_request_18">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/golrabas/-1/comments/17 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 36
 
 {
@@ -2596,9 +3108,9 @@ Content-Length: 36
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_13"><a class="link" href="#_response_13">2.3.6. Response</a></h4>
+<h4 id="_response_15"><a class="link" href="#_response_15">2.3.6. Response</a></h4>
 <div class="sect4">
-<h5 id="_http_response_16"><a class="link" href="#_http_response_16">HTTP Response</a></h5>
+<h5 id="_http_response_18"><a class="link" href="#_http_response_18">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
@@ -2607,7 +3119,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Connection: close
 Content-Length: 92
 
@@ -2625,7 +3137,7 @@ Content-Length: 92
 <div class="sect4">
 <h5 id="_path_parameter_7"><a class="link" href="#_path_parameter_7">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. /api/golrabas/{questionId}/comments/{commentId}</caption>
+<caption class="title">Table 15. /api/golrabas/{questionId}/comments/{commentId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2673,13 +3185,13 @@ Content-Length: 92
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_17"><a class="link" href="#_http_request_17">HTTP Request</a></h5>
+<h5 id="_http_request_19"><a class="link" href="#_http_request_19">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/golrabas/35/comments/20 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 35
 
 {
@@ -2690,9 +3202,9 @@ Content-Length: 35
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_14"><a class="link" href="#_response_14">2.3.8. Response</a></h4>
+<h4 id="_response_16"><a class="link" href="#_response_16">2.3.8. Response</a></h4>
 <div class="sect4">
-<h5 id="_http_response_17"><a class="link" href="#_http_response_17">HTTP Response</a></h5>
+<h5 id="_http_response_19"><a class="link" href="#_http_response_19">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
@@ -2701,7 +3213,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Connection: close
 Content-Length: 105
 
@@ -2721,11 +3233,11 @@ Content-Length: 105
 <p>API : <code>GET /api/golrabas/{questionId}/comments/</code></p>
 </div>
 <div class="sect3">
-<h4 id="_성공_8"><a class="link" href="#_성공_8">2.4.1. 성공</a></h4>
+<h4 id="_성공_10"><a class="link" href="#_성공_10">2.4.1. 성공</a></h4>
 <div class="sect4">
 <h5 id="_path_parameter_8"><a class="link" href="#_path_parameter_8">Path Parameter</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. /api/golrabas/{questionId}/comments</caption>
+<caption class="title">Table 16. /api/golrabas/{questionId}/comments</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2745,21 +3257,21 @@ Content-Length: 105
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_18"><a class="link" href="#_http_request_18">HTTP Request</a></h5>
+<h5 id="_http_request_20"><a class="link" href="#_http_request_20">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/30/comments?searchAfterId=15&amp;size=5 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_15"><a class="link" href="#_response_15">2.4.2. Response</a></h4>
+<h4 id="_response_17"><a class="link" href="#_response_17">2.4.2. Response</a></h4>
 <div class="sect4">
-<h5 id="_http_response_18"><a class="link" href="#_http_response_18">HTTP Response</a></h5>
+<h5 id="_http_response_20"><a class="link" href="#_http_response_20">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2768,7 +3280,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:05 GMT
+Date: Sun, 08 Oct 2023 16:55:17 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 724
@@ -2848,13 +3360,13 @@ Content-Length: 724
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_19"><a class="link" href="#_http_request_19">HTTP Request</a></h5>
+<h5 id="_http_request_21"><a class="link" href="#_http_request_21">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/golrabas/shortUrl HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147
+Host: localhost:59907
 Content-Length: 35
 
 {
@@ -2865,9 +3377,9 @@ Content-Length: 35
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_16"><a class="link" href="#_response_16">3.1.2. Response</a></h4>
+<h4 id="_response_18"><a class="link" href="#_response_18">3.1.2. Response</a></h4>
 <div class="sect4">
-<h5 id="_response_fields_7"><a class="link" href="#_response_fields_7">Response Fields</a></h5>
+<h5 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2901,7 +3413,7 @@ Content-Length: 35
 </table>
 </div>
 <div class="sect4">
-<h5 id="_response_body_13"><a class="link" href="#_response_body_13">Response Body</a></h5>
+<h5 id="_response_body_15"><a class="link" href="#_response_body_15">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -2915,7 +3427,7 @@ Content-Length: 35
 </div>
 </div>
 <div class="sect4">
-<h5 id="_http_response_19"><a class="link" href="#_http_response_19">HTTP Response</a></h5>
+<h5 id="_http_response_21"><a class="link" href="#_http_response_21">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2924,7 +3436,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 131
@@ -2949,9 +3461,9 @@ Content-Length: 131
 <div class="sect3">
 <h4 id="_request_6"><a class="link" href="#_request_6">3.2.1. Request</a></h4>
 <div class="sect4">
-<h5 id="_path_parameters_7"><a class="link" href="#_path_parameters_7">Path Parameters</a></h5>
+<h5 id="_path_parameters_9"><a class="link" href="#_path_parameters_9">Path Parameters</a></h5>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 15. /api/golrabas/shortUrl/{shortUrl}</caption>
+<caption class="title">Table 17. /api/golrabas/shortUrl/{shortUrl}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2971,21 +3483,21 @@ Content-Length: 131
 </table>
 </div>
 <div class="sect4">
-<h5 id="_http_request_20"><a class="link" href="#_http_request_20">HTTP Request</a></h5>
+<h5 id="_http_request_22"><a class="link" href="#_http_request_22">HTTP Request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/golrabas/shortUrl/Sq3pFB HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Host: localhost:60147</code></pre>
+Host: localhost:59907</code></pre>
 </div>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_17"><a class="link" href="#_response_17">3.2.2. Response</a></h4>
+<h4 id="_response_19"><a class="link" href="#_response_19">3.2.2. Response</a></h4>
 <div class="sect4">
-<h5 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h5>
+<h5 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3019,7 +3531,7 @@ Host: localhost:60147</code></pre>
 </table>
 </div>
 <div class="sect4">
-<h5 id="_response_body_14"><a class="link" href="#_response_body_14">Response Body</a></h5>
+<h5 id="_response_body_16"><a class="link" href="#_response_body_16">Response Body</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
@@ -3033,7 +3545,7 @@ Host: localhost:60147</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_http_response_20"><a class="link" href="#_http_response_20">HTTP Response</a></h5>
+<h5 id="_http_response_22"><a class="link" href="#_http_response_22">HTTP Response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3042,7 +3554,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sat, 07 Oct 2023 10:01:07 GMT
+Date: Sun, 08 Oct 2023 16:55:18 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 139

--- a/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
+++ b/src/test/java/donggi/dev/kkeuroolryo/web/question/QuestionReadRestControllerRestDocsTest.java
@@ -207,6 +207,93 @@ class QuestionReadRestControllerRestDocsTest extends InitRestDocsTest {
     }
 
     @Test
+    @DisplayName("카테고리로 질문 리스트 조회 요청이 정상적이면 질문 리스트를 반환하고 정상 상태코드를 반환한다.")
+    void question_list_read_by_category() {
+        given(this.spec)
+            .filter(
+                document("question-list-read-by-category",
+                    pathParameters(parameterWithName("category").description("조회할 카테고리")),
+                    queryParameters(
+                        parameterWithName("searchAfterId").description("검색 시작할 댓글 id"),
+                        parameterWithName("size").description("조회할 데이터 개수")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 코드").type(JsonFieldType.STRING),
+                        fieldWithPath("message").description("응답 메세지").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].id").description("질문 id").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.questions[].content").description("질문 본문").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].choiceA").description("선택지 A").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].choiceB").description("선택지 B").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].active").description("활성화 상태").type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.questions[].choiceAResult").description("선택지 A의 득표율").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.questions[].choiceBResult").description("선택지 B의 득표율").type(JsonFieldType.NUMBER),
+
+                        fieldWithPath("data.page.size").description("조회된 데이터 개수").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.page.nextId").description("다음 데이터 id").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.page.last").description("마지막 여부").type(JsonFieldType.BOOLEAN)
+                    )
+                )
+            )
+            .log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-type", MediaType.APPLICATION_JSON_VALUE)
+            .queryParam("searchAfterId", question.getId())
+            .queryParam("size", 5)
+
+        .when()
+            .get("/api/golrabas/category/{category}/question", question.getCategory())
+
+        .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("특정 active 상태와 카테고리로 질문 리스트 조회 요청이 정상적이면 질문 리스트를 반환하고 정상 상태코드를 반환한다.")
+    void question_list_read_by_category_and_active() {
+        given(this.spec)
+            .filter(
+                document("question-list-read-by-category-and-active",
+                    pathParameters(
+                        parameterWithName("category").description("조회할 카테고리"),
+                        parameterWithName("active").description("조회할 active 상태")
+                    ),
+                    queryParameters(
+                        parameterWithName("searchAfterId").description("검색 시작할 댓글 id"),
+                        parameterWithName("size").description("조회할 데이터 개수")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 코드").type(JsonFieldType.STRING),
+                        fieldWithPath("message").description("응답 메세지").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].id").description("질문 id").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.questions[].content").description("질문 본문").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].choiceA").description("선택지 A").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].choiceB").description("선택지 B").type(JsonFieldType.STRING),
+                        fieldWithPath("data.questions[].active").description("활성화 상태").type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.questions[].choiceAResult").description("선택지 A의 득표율").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.questions[].choiceBResult").description("선택지 B의 득표율").type(JsonFieldType.NUMBER),
+
+                        fieldWithPath("data.page.size").description("조회된 데이터 개수").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.page.nextId").description("다음 데이터 id").type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.page.last").description("마지막 여부").type(JsonFieldType.BOOLEAN)
+                    )
+                )
+            )
+            .log().all()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-type", MediaType.APPLICATION_JSON_VALUE)
+            .queryParam("searchAfterId", question.getId())
+            .queryParam("size", 5)
+
+        .when()
+            .get("/api/golrabas/category/{category}/question/active/{active}", question.getCategory(), question.isActive())
+
+        .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
     @DisplayName("질문 키워드 검색 요청이 정상적이면 키워드로 검색한 질문 리스트를 반환하고 정상 상태코드를 반환한다.")
     void question_search() {
         String keyword = "질문";


### PR DESCRIPTION
### ❗️ 이슈 번호

#number

<br>

### 📝 구현 내용

- 카테고리와 active 상태에 맞는 질문 리스트 조회 API 추가

<br>

### 💡 결과 & 참고 자료

- **전체 테스트 결과**
<img width="672" alt="image" src="https://github.com/beside-kkeuroolryo/golraba/assets/73376468/6aa9f663-8e6b-4d71-8214-cb1439568a6b">

